### PR TITLE
fix: sanitize paths for file events and removal

### DIFF
--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -90,6 +90,9 @@ func New(ctx context.Context, c *cli.Context, log *logrus.Logger) error {
 					metricPath = strings.ReplaceAll(metricPath, c.String("rootfs"), "")
 				}
 
+				metricPath = filepath.Clean(metricPath)
+				metricPath = filepath.ToSlash(metricPath)
+
 				fileEvent.WithLabelValues(metricPath, event.Op.String()).Inc()
 
 				if event.Op == watcher.Remove {


### PR DESCRIPTION
This fixes a path issue with file event metrics and removal of metrics when a file is removed by sanitizing the path like we do when generating metrics.