### PR TITLE
Windows fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
       - id: version
         run: |
           echo "::set-output name=version::$(cat releases/metadata.json | jq -r '.version')"
-          echo "::set-output name=windows::$(cat releases/metadata.json | jq -r '.version | split("-") | if length == 1 then .[0] else ([.[0],.[1]] | join(".")) end')"
+          echo "::set-output name=windows::$(cat releases/metadata.json | jq -r '.version | split("-") | if length == 1 then .[0] else ([.[0],.[1]] | join(".") | sub("rc"; "")) end')"
     outputs:
       version: ${{ steps.version.outputs.version }}
       windows-version: ${{ steps.version.outputs.windows }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,10 @@ builds:
     ldflags:
       - -s
       - -w
+      - -X '{{ .ModulePath }}/pkg/common.SUMMARY=v{{ .Version }}'
+      - -X '{{ .ModulePath }}/pkg/common.BRANCH={{ .Branch }}'
+      - -X '{{ .ModulePath }}/pkg/common.VERSION={{ .Tag }}'
+      - -X '{{ .ModulePath }}/pkg/common.COMMIT={{ .Commit }}'
 
 signs:
   - id: cosign

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,12 @@ builds:
       - -X '{{ .ModulePath }}/pkg/common.VERSION={{ .Tag }}'
       - -X '{{ .ModulePath }}/pkg/common.COMMIT={{ .Commit }}'
 
+archives:
+  - id: default
+    format_overrides:
+      - goos: windows
+        format: zip
+
 signs:
   - id: cosign
     cmd: cosign

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,6 +54,8 @@ release:
   prerelease: auto
   extra_files:
     - glob: ./cosign.pub
+  footer: |
+    **Note:** The windows `msi` is generated outside of [goreleaser](https://goreleaser.com/) and therefore is not included in the checksums file for validation.
 
 dockers:
   - use: buildx

--- a/pkg/commands/global.go
+++ b/pkg/commands/global.go
@@ -25,6 +25,8 @@ func globalFlags() []cli.Flag {
 
 func globalBefore(c *cli.Context) error {
 	switch c.String("log-level") {
+	case "trace":
+		logrus.SetLevel(logrus.TraceLevel)
 	case "debug":
 		logrus.SetLevel(logrus.DebugLevel)
 	case "info":


### PR DESCRIPTION
- Fixes version information on binary build
- Adds support for trace log level
- Process all currently watched files every 30 seconds
- Re-add path watches if file deleted error is thrown